### PR TITLE
use codeclimate's alpine-ruby image to avoid breaking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM codeclimate/alpine-ruby:b38
 
 WORKDIR /usr/src/app
 COPY Gemfile /usr/src/app/


### PR DESCRIPTION
@codeclimate/review Updates `coffeelint` to use our `alpine` image, instead of `alpine/edge`, as in [rubocop PR](https://github.com/codeclimate/codeclimate-rubocop/pull/11).
