### PR TITLE
Analyze all .coffee files when include_paths is ./

### DIFF
--- a/lib/cc/engine/analyzable_files.rb
+++ b/lib/cc/engine/analyzable_files.rb
@@ -19,7 +19,7 @@ module CC
       def fetch_files(paths)
         paths.map do |path|
           if path =~ %r{/$}
-            Dir.glob("#{path}/**/*.coffee")
+            Dir.glob("#{path}**/*.coffee")
           else
             path if path =~ /\.coffee$/
           end
@@ -27,7 +27,11 @@ module CC
       end
 
       def build_files_with_inclusions(inclusions)
-        fetch_files(inclusions)
+        if inclusions == ["./"]
+          Dir.glob("**/*.coffee")
+        else
+          fetch_files(inclusions)
+        end
       end
 
       def build_files_with_exclusions(exclusions)

--- a/lib/cc/engine/analyzable_files.rb
+++ b/lib/cc/engine/analyzable_files.rb
@@ -1,8 +1,7 @@
 module CC
   module Engine
     class AnalyzableFiles
-      def initialize(directory, config)
-        @directory = directory
+      def initialize(config)
         @config = config
       end
 
@@ -35,9 +34,9 @@ module CC
       end
 
       def build_files_with_exclusions(exclusions)
-        files = Dir.glob("#{@directory}/**/*.coffee")
+        files = Dir.glob("**/*.coffee")
         excluded_files = fetch_files(exclusions)
-        files.reject { |f| exclusions.include?(f) }
+        files - excluded_files
       end
     end
   end

--- a/lib/cc/engine/coffeelint.rb
+++ b/lib/cc/engine/coffeelint.rb
@@ -9,6 +9,8 @@ module CC
         @directory = directory
         @engine_config = engine_config
         @io = io
+
+        Dir.chdir("/code")
       end
 
       def run
@@ -49,7 +51,7 @@ module CC
       def coffeelint_results
         unless @coffeelint_results
           runner = CoffeelintResults.new(
-            @directory, config: @engine_config['config']
+            config: @engine_config['config']
           )
           @coffeelint_results = runner.results
         end

--- a/lib/cc/engine/coffeelint.rb
+++ b/lib/cc/engine/coffeelint.rb
@@ -10,7 +10,7 @@ module CC
         @engine_config = engine_config
         @io = io
 
-        Dir.chdir("/code")
+        Dir.chdir(@directory)
       end
 
       def run

--- a/lib/cc/engine/coffeelint.rb
+++ b/lib/cc/engine/coffeelint.rb
@@ -50,9 +50,7 @@ module CC
 
       def coffeelint_results
         unless @coffeelint_results
-          runner = CoffeelintResults.new(
-            config: @engine_config['config']
-          )
+          runner = CoffeelintResults.new(@engine_config['config'])
           @coffeelint_results = runner.results
         end
         @coffeelint_results

--- a/lib/cc/engine/coffeelint.rb
+++ b/lib/cc/engine/coffeelint.rb
@@ -45,7 +45,7 @@ module CC
       end
 
       def analyzable_files
-        @files ||= AnalyzableFiles.new(@directory, @engine_config).all
+        @files ||= AnalyzableFiles.new(@engine_config).all
       end
 
       def coffeelint_results

--- a/lib/cc/engine/coffeelint_results.rb
+++ b/lib/cc/engine/coffeelint_results.rb
@@ -1,8 +1,7 @@
 module CC
   module Engine
     class CoffeelintResults
-      def initialize(directory, config: nil)
-        @directory = directory
+      def initialize(config: nil)
         @config = config
       end
 
@@ -10,9 +9,7 @@ module CC
         cmd = "coffeelint"
         cmd << " -f #{@config}" if @config
         cmd << " -q --reporter raw ."
-        Dir.chdir(@directory) do
-          JSON.parse(`#{cmd}`)
-        end
+        JSON.parse(`#{cmd}`)
       end
     end
   end

--- a/lib/cc/engine/coffeelint_results.rb
+++ b/lib/cc/engine/coffeelint_results.rb
@@ -1,7 +1,7 @@
 module CC
   module Engine
     class CoffeelintResults
-      def initialize(config: nil)
+      def initialize(config)
         @config = config
       end
 

--- a/spec/cc/engine/analyzable_files_spec.rb
+++ b/spec/cc/engine/analyzable_files_spec.rb
@@ -14,61 +14,61 @@ module CC::Engine
       FileUtils.rm_rf(tmp_dir)
     end
 
-    context "when config has include_paths" do
-      context "when given explicit paths" do
-        it "returns files matching only those paths" do
-          make_file("exclude.coffee")
-          make_file("foo/bar.coffee")
-          make_file("bar/foo.coffee")
+    context 'when config has include_paths' do
+      context 'when given explicit paths' do
+        it 'returns files matching only those paths' do
+          make_file('exclude.coffee')
+          make_file('foo/bar.coffee')
+          make_file('bar/foo.coffee')
 
           analyzable_files = AnalyzableFiles.new({
-            "include_paths" => ["foo/", "bar/"]
+            'include_paths' => ['foo/', 'bar/']
           })
           expect(analyzable_files.all.sort).to eq([
-            "bar/foo.coffee",
-            "foo/bar.coffee",
+            'bar/foo.coffee',
+            'foo/bar.coffee'
           ])
         end
       end
 
-      context "when given ./" do
-        it "returns all files in the current directory" do
-          make_file("root.coffee")
-          make_file("foo/bar.coffee")
-          make_file("foo/baz/wat.coffee")
+      context 'when given ./' do
+        it 'returns all files in the current directory' do
+          make_file('root.coffee')
+          make_file('foo/bar.coffee')
+          make_file('foo/baz/wat.coffee')
 
           analyzable_files = AnalyzableFiles.new({
-            "include_paths" => ["./"]
+            'include_paths' => ['./']
           })
           expect(analyzable_files.all.sort).to eq([
-            "foo/bar.coffee",
-            "foo/baz/wat.coffee",
-            "root.coffee",
+            'foo/bar.coffee',
+            'foo/baz/wat.coffee',
+            'root.coffee'
           ])
         end
       end
     end
 
-    context "when config has exclude_paths" do
-      it "excludes files that match exclude_paths" do
-        make_file("root.coffee")
-        make_file("foo/bar.coffee")
-        make_file("bar/foo.coffee")
+    context 'when config has exclude_paths' do
+      it 'excludes files that match exclude_paths' do
+        make_file('root.coffee')
+        make_file('foo/bar.coffee')
+        make_file('bar/foo.coffee')
 
         analyzable_files = AnalyzableFiles.new({
-          "exclude_paths" => ["bar/"]
+          'exclude_paths' => ['bar/']
         })
         expect(analyzable_files.all.sort).to eq([
-          "foo/bar.coffee",
-          "root.coffee"
+          'foo/bar.coffee',
+          'root.coffee'
         ])
       end
     end
 
     def make_file(name)
       FileUtils.mkdir_p(File.dirname(name))
-      File.open(name, "w") do |f|
-        f.write('console.log "hello!"')
+      File.open(name, 'w') do |f|
+        f.write("console.log 'hello!'")
       end
     end
   end

--- a/spec/cc/engine/analyzable_files_spec.rb
+++ b/spec/cc/engine/analyzable_files_spec.rb
@@ -24,9 +24,9 @@ module CC::Engine
           analyzable_files = AnalyzableFiles.new({
             "include_paths" => ["foo/", "bar/"]
           })
-          expect(analyzable_files.all).to eq([
-            "foo/bar.coffee",
+          expect(analyzable_files.all.sort).to eq([
             "bar/foo.coffee",
+            "foo/bar.coffee",
           ])
         end
       end
@@ -40,7 +40,7 @@ module CC::Engine
           analyzable_files = AnalyzableFiles.new({
             "include_paths" => ["./"]
           })
-          expect(analyzable_files.all).to eq([
+          expect(analyzable_files.all.sort).to eq([
             "foo/bar.coffee",
             "foo/baz/wat.coffee",
             "root.coffee",
@@ -58,7 +58,7 @@ module CC::Engine
         analyzable_files = AnalyzableFiles.new({
           "exclude_paths" => ["bar/"]
         })
-        expect(analyzable_files.all).to eq([
+        expect(analyzable_files.all.sort).to eq([
           "foo/bar.coffee",
           "root.coffee"
         ])

--- a/spec/cc/engine/analyzable_files_spec.rb
+++ b/spec/cc/engine/analyzable_files_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+require 'tmpdir'
+require 'fileutils'
+
+module CC::Engine
+  describe AnalyzableFiles do
+    around do |example|
+      tmp_dir = Dir.mktmpdir
+
+      Dir.chdir(tmp_dir) do
+        example.run
+      end
+
+      FileUtils.rm_rf(tmp_dir)
+    end
+
+    context "when config has include_paths" do
+      context "when given explicit paths" do
+        it "returns files matching only those paths" do
+          make_file("exclude.coffee")
+          make_file("foo/bar.coffee")
+          make_file("bar/foo.coffee")
+
+          analyzable_files = AnalyzableFiles.new({
+            "include_paths" => ["foo/", "bar/"]
+          })
+          expect(analyzable_files.all).to eq([
+            "foo/bar.coffee",
+            "bar/foo.coffee",
+          ])
+        end
+      end
+
+      context "when given ./" do
+        it "returns all files in the current directory" do
+          make_file("root.coffee")
+          make_file("foo/bar.coffee")
+          make_file("foo/baz/wat.coffee")
+
+          analyzable_files = AnalyzableFiles.new({
+            "include_paths" => ["./"]
+          })
+          expect(analyzable_files.all).to eq([
+            "foo/bar.coffee",
+            "foo/baz/wat.coffee",
+            "root.coffee",
+          ])
+        end
+      end
+    end
+
+    context "when config has exclude_paths" do
+      it "excludes files that match exclude_paths" do
+        make_file("root.coffee")
+        make_file("foo/bar.coffee")
+        make_file("bar/foo.coffee")
+
+        analyzable_files = AnalyzableFiles.new({
+          "exclude_paths" => ["bar/"]
+        })
+        expect(analyzable_files.all).to eq([
+          "foo/bar.coffee",
+          "root.coffee"
+        ])
+      end
+    end
+
+    def make_file(name)
+      FileUtils.mkdir_p(File.dirname(name))
+      File.open(name, "w") do |f|
+        f.write('console.log "hello!"')
+      end
+    end
+  end
+end

--- a/spec/cc/engine/coffeelint_results_spec.rb
+++ b/spec/cc/engine/coffeelint_results_spec.rb
@@ -4,7 +4,7 @@ module CC::Engine
   describe CoffeelintResults do
     describe "#results" do
       it "passes in a config file if specified" do
-        results = CoffeelintResults.new(".", config: "mycoffeelint.json")
+        results = CoffeelintResults.new(config: "mycoffeelint.json")
         expected_cmd = "coffeelint -f mycoffeelint.json -q --reporter raw ."
         expect(results).to \
           receive(:`).with(expected_cmd).and_return("{}")

--- a/spec/cc/engine/coffeelint_results_spec.rb
+++ b/spec/cc/engine/coffeelint_results_spec.rb
@@ -4,7 +4,7 @@ module CC::Engine
   describe CoffeelintResults do
     describe "#results" do
       it "passes in a config file if specified" do
-        results = CoffeelintResults.new(config: "mycoffeelint.json")
+        results = CoffeelintResults.new("mycoffeelint.json")
         expected_cmd = "coffeelint -f mycoffeelint.json -q --reporter raw ."
         expect(results).to \
           receive(:`).with(expected_cmd).and_return("{}")


### PR DESCRIPTION
When the `fetch_files` method is passed `./` we run into two problems.
1. It attempts to glob `.//**/*.coffee` which has an extra `/`
2. It prepends `./` to all the results of the glob which aren't present on the results we receive later.

The second issue is a problem because the results returned from coffeelint do not have the `./` prefix which causes none of the files to match leaving us with no results.

We also have to `Dir.chdir` before we do anything otherwise parts of the engine work on the wrong paths.
