### PR TITLE
Remove excluded_paths support

### DIFF
--- a/lib/cc/engine/analyzable_files.rb
+++ b/lib/cc/engine/analyzable_files.rb
@@ -1,39 +1,24 @@
 module CC
   module Engine
     class AnalyzableFiles
-      def initialize(directory, config)
-        @directory = directory
+      def initialize(config)
         @config = config
       end
 
       def all
-        @results ||= if @config["include_paths"]
-          build_files_with_inclusions(@config["include_paths"])
+        @results ||= if (include_paths = @config["include_paths"])
+          filter_files(include_paths)
         else
-          build_files_with_exclusions(@config["exclude_paths"] || [])
+          fail "error: `include_paths' not provided\nThis is probably due to an old version of the codeclimate CLI being used. Please try updating."
         end
       end
 
       private
 
-      def fetch_files(paths)
-        paths.map do |path|
-          if path =~ %r{/$}
-            Dir.glob("#{path}/**/*.coffee")
-          else
-            path if path =~ /\.coffee$/
-          end
-        end.flatten.compact
-      end
-
-      def build_files_with_inclusions(inclusions)
-        fetch_files(inclusions)
-      end
-
-      def build_files_with_exclusions(exclusions)
-        files = Dir.glob("#{@directory}/**/*.coffee")
-        excluded_files = fetch_files(exclusions)
-        files.reject { |f| exclusions.include?(f) }
+      def filter_files(files)
+        files.select do |file|
+          file.end_with?("/") || file.end_with?(".coffee")
+        end
       end
     end
   end

--- a/lib/cc/engine/coffeelint.rb
+++ b/lib/cc/engine/coffeelint.rb
@@ -13,43 +13,38 @@ module CC
 
       def run
         coffeelint_results.each do |path, errors|
-          path = path.gsub(/\A\.\//, '')
-          if include_path?(path)
-            errors.each do |error|
-              issue = {
-                type: "Issue",
-                description: error["message"],
-                check_name: error["rule"],
-                categories: [category(error['name'])],
-                location: {
-                  path: path,
-                  lines: {
-                    begin: error["lineNumber"],
-                    end: error["lineNumber"]
-                  }
-                },
-                remediation_points: remediation_points(error['name'])
-              }
-              @io.print("#{issue.to_json}\0")
-            end
+          errors.each do |error|
+            issue = {
+              type: "Issue",
+              description: error["message"],
+              check_name: error["rule"],
+              categories: [category(error['name'])],
+              location: {
+                path: path,
+                lines: {
+                  begin: error["lineNumber"],
+                  end: error["lineNumber"]
+                }
+              },
+              remediation_points: remediation_points(error['name'])
+            }
+            @io.print("#{issue.to_json}\0")
           end
         end
       end
 
       private
 
-      def include_path?(path)
-        analyzable_files.include?(path)
-      end
-
       def analyzable_files
-        @files ||= AnalyzableFiles.new(@directory, @engine_config).all
+        @files ||= AnalyzableFiles.new(@engine_config).all
       end
 
       def coffeelint_results
         unless @coffeelint_results
           runner = CoffeelintResults.new(
-            @directory, config: @engine_config['config']
+            @directory,
+            analyzable_files,
+            @engine_config['config']
           )
           @coffeelint_results = runner.results
         end

--- a/lib/cc/engine/coffeelint_results.rb
+++ b/lib/cc/engine/coffeelint_results.rb
@@ -1,15 +1,19 @@
+require 'shellwords'
+
 module CC
   module Engine
     class CoffeelintResults
-      def initialize(directory, config: nil)
+      def initialize(directory, files, config)
         @directory = directory
         @config = config
+        @files = files
       end
 
       def results
+        escaped_files = Shellwords.join(@files)
         cmd = "coffeelint"
         cmd << " -f #{@config}" if @config
-        cmd << " -q --reporter raw ."
+        cmd << " -q --reporter raw #{escaped_files}"
         Dir.chdir(@directory) do
           JSON.parse(`#{cmd}`)
         end

--- a/spec/cc/engine/analyzable_files_spec.rb
+++ b/spec/cc/engine/analyzable_files_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+module CC::Engine
+  describe AnalyzableFiles do
+    context "when given include_paths" do
+      it "filters out non-directory and non-coffee files" do
+        analyzable_files = AnalyzableFiles.new({
+          "include_paths" => ["foo/", "bar.py", "foo.coffee"]
+        })
+
+        expect(analyzable_files.all.sort).to eq(["foo.coffee", "foo/"])
+      end
+    end
+
+    context "when given exclude_paths" do
+      it "raises" do
+        analyzable_files = AnalyzableFiles.new({
+          "exclude_paths" => []
+        })
+
+        expect{analyzable_files.all}.to raise_error
+      end
+    end
+  end
+end

--- a/spec/cc/engine/coffeelint_results_spec.rb
+++ b/spec/cc/engine/coffeelint_results_spec.rb
@@ -4,7 +4,7 @@ module CC::Engine
   describe CoffeelintResults do
     describe "#results" do
       it "passes in a config file if specified" do
-        results = CoffeelintResults.new(".", config: "mycoffeelint.json")
+        results = CoffeelintResults.new(".", ["."], "mycoffeelint.json")
         expected_cmd = "coffeelint -f mycoffeelint.json -q --reporter raw ."
         expect(results).to \
           receive(:`).with(expected_cmd).and_return("{}")


### PR DESCRIPTION
This removes excluded_paths support and now passes a filtered version of
`include_paths` that removes non-directory, non `.coffee` files directly
to `coffeelint` itself.
