### PR TITLE
Use docker to run tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,11 +14,12 @@ dependencies:
     - curl https://sdk.cloud.google.com | bash
     - gcloud auth activate-service-account $gcloud_account_email --key-file /tmp/gcloud_key.json
     - gcloud docker -a
+  override:
+    - docker build -t=$registry_root/$image_name:b$CIRCLE_BUILD_NUM .
 
 test:
   override:
-    - bundle exec rake
-    - docker build -t=$registry_root/$image_name:b$CIRCLE_BUILD_NUM .
+    - docker run $registry_root/$image_name:b$CIRCLE_BUILD_NUM bundle exec rake
 
 deployment:
   registry:


### PR DESCRIPTION
Since we don't install `coffeelint` on CircleCI we need to use the
docker container to run the tests since it installs all of our
dependencies.
