### PR TITLE
Treat empty string as no config specified

### DIFF
--- a/lib/cc/engine/coffeelint_results.rb
+++ b/lib/cc/engine/coffeelint_results.rb
@@ -12,7 +12,7 @@ module CC
       def results
         escaped_files = Shellwords.join(@files)
         cmd = "coffeelint"
-        cmd << " -f #{@config}" if @config
+        cmd << " -f #{@config}" if @config && @config != ""
         cmd << " -q --reporter raw #{escaped_files}"
         Dir.chdir(@directory) do
           JSON.parse(`#{cmd}`)

--- a/spec/cc/engine/coffeelint_results_spec.rb
+++ b/spec/cc/engine/coffeelint_results_spec.rb
@@ -10,6 +10,14 @@ module CC::Engine
           receive(:`).with(expected_cmd).and_return("{}")
         results.results
       end
+
+      it "passes no config if file path is empty string" do
+        results = CoffeelintResults.new(".", ["."], "")
+        expected_cmd = "coffeelint -q --reporter raw ."
+        expect(results).to \
+          receive(:`).with(expected_cmd).and_return("{}")
+        results.results
+      end
     end
   end
 end


### PR DESCRIPTION
At the moment, `codeclimate engines:enable coffeelint` adds to
a user's .codeclimate.yml:

```
engines:
  coffeelint:
    enabled: true
    config:

```

Coffeelint treats that as `config: ""` and blows up, which is confusing behavior for a first time user.
This change fixes the behavior on the engine side, which matches the behavior of other engines, like [codeclimate-eslint](https://github.com/codeclimate/codeclimate-eslint/blob/master/bin/eslint.js#L171), which doesn't have this problem because `""` is falsey in javascript.

cc @codeclimate/review 
