### PR TITLE
Return No Results if there are no Analyzable files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: image citest test
+
+IMAGE_NAME ?= codeclimate/codeclimate-coffeelint
+
+image:
+	docker build --tag $(IMAGE_NAME) .
+
+citest:
+	docker run --rm $(IMAGE_NAME) bundle exec rake
+
+test: image citest

--- a/circle.yml
+++ b/circle.yml
@@ -3,15 +3,14 @@ machine:
     - docker
   environment:
     CLOUDSDK_CORE_DISABLE_PROMPTS: 1
-    image_name: codeclimate-coffeelint
 
 dependencies:
   override:
-    - docker build -t=$registry_root/$image_name:b$CIRCLE_BUILD_NUM .
+    - make image
 
 test:
   override:
-    - docker run $registry_root/$image_name:b$CIRCLE_BUILD_NUM bundle exec rake
+    - make citest
 
 deployment:
   registry:
@@ -20,8 +19,9 @@ deployment:
     commands:
       - curl https://sdk.cloud.google.com | bash
       - echo $gcloud_json_key_base64 | sed 's/ //g' | base64 -d > /tmp/gcloud_key.json
+      - docker tag codeclimate/codeclimate-coffeelint $registry_root/codeclimate-coffeelint:b$CIRCLE_BUILD_NUM
       - gcloud auth activate-service-account $gcloud_account_email --key-file /tmp/gcloud_key.json
-      - gcloud docker push $registry_root/$image_name:b$CIRCLE_BUILD_NUM
+      - gcloud docker push $registry_root/codeclimate-coffeelint:b$CIRCLE_BUILD_NUM
 
 notify:
   webhooks:

--- a/circle.yml
+++ b/circle.yml
@@ -6,11 +6,6 @@ machine:
     image_name: codeclimate-coffeelint
 
 dependencies:
-  pre:
-    - echo $gcloud_json_key_base64 | sed 's/ //g' | base64 -d > /tmp/gcloud_key.json
-    - curl https://sdk.cloud.google.com | bash
-    - gcloud auth activate-service-account $gcloud_account_email --key-file /tmp/gcloud_key.json
-    - gcloud docker -a
   override:
     - docker build -t=$registry_root/$image_name:b$CIRCLE_BUILD_NUM .
 
@@ -21,5 +16,13 @@ test:
 deployment:
   registry:
     branch: master
+    owner: codeclimate
     commands:
-      - docker push $registry_root/$image_name:b$CIRCLE_BUILD_NUM
+      - curl https://sdk.cloud.google.com | bash
+      - echo $gcloud_json_key_base64 | sed 's/ //g' | base64 -d > /tmp/gcloud_key.json
+      - gcloud auth activate-service-account $gcloud_account_email --key-file /tmp/gcloud_key.json
+      - gcloud docker push $registry_root/$image_name:b$CIRCLE_BUILD_NUM
+
+notify:
+  webhooks:
+    - url: https://cc-slack-proxy.herokuapp.com/circle

--- a/lib/cc/engine/coffeelint_results.rb
+++ b/lib/cc/engine/coffeelint_results.rb
@@ -10,6 +10,8 @@ module CC
       end
 
       def results
+        return [] if @files.empty?
+
         escaped_files = Shellwords.join(@files)
         cmd = "coffeelint"
         cmd << " -f #{@config}" if @config

--- a/spec/cc/engine/coffeelint_spec.rb
+++ b/spec/cc/engine/coffeelint_spec.rb
@@ -46,6 +46,21 @@ module CC::Engine
         expect(io).to have_received(:print).exactly(3).times
       end
 
+      it "prints out no results if there are no analyzable files" do
+        make_file("foo.rb", "a" * 90)
+        io = double(print: nil)
+
+        Coffeelint.new(
+          directory: Dir.pwd,
+          io: io,
+          engine_config: {
+            "include_paths" => ["foo.rb"]
+          }
+        ).run
+
+        expect(io).to have_received(:print).exactly(0).times
+      end
+
       it "prints out the proper message" do
         make_file("foo.coffee", "a" * 90)
         io = double(print: nil)


### PR DESCRIPTION
When running this engine from the codeclimate cli to analyze a single
file, if the file is not analyzable the coffeelint engine throws the
following error:

> Running coffeelint: Done!
> error: (CC::Analyzer::Engine::EngineFailure) engine coffeelint failed
> with status 1

The current fix prevents the engine of parsing non existing results when
running against a file that is not analyzable.

Added a spec in coffeelint_spec to validate this.
