### PR TITLE
Add Makefile, build image at generic name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: image citest test
+
+IMAGE_NAME ?= codeclimate/codeclimate-coffeelint
+
+image:
+	docker build --tag $(IMAGE_NAME) .
+
+citest:
+	docker run --rm $(IMAGE_NAME) bundle exec rake
+
+test: image citest

--- a/circle.yml
+++ b/circle.yml
@@ -3,15 +3,14 @@ machine:
     - docker
   environment:
     CLOUDSDK_CORE_DISABLE_PROMPTS: 1
-    image_name: codeclimate-coffeelint
 
 dependencies:
   override:
-    - docker build -t=$registry_root/$image_name:b$CIRCLE_BUILD_NUM .
+    - make image
 
 test:
   override:
-    - docker run $registry_root/$image_name:b$CIRCLE_BUILD_NUM bundle exec rake
+    - make citest
 
 deployment:
   registry:
@@ -20,8 +19,9 @@ deployment:
     commands:
       - curl https://sdk.cloud.google.com | bash
       - echo $gcloud_json_key_base64 | sed 's/ //g' | base64 -d > /tmp/gcloud_key.json
+      - docker tag codeclimate/codeclimate-coffeelint $registry_root/codeclimate-coffeelint:b$CIRCLE_BUILD_NUM
       - gcloud auth activate-service-account $gcloud_account_email --key-file /tmp/gcloud_key.json
-      - gcloud docker push $registry_root/$image_name:b$CIRCLE_BUILD_NUM
+      - gcloud docker push $registry_root/codeclimate-coffeelint:b$CIRCLE_BUILD_NUM
 
 notify:
   webhooks:


### PR DESCRIPTION
Relying on the registry variable in the Circle env means this won't work on
non-codeclimate forks. This also brings the engine in line with how we manage
engine projects in general.

/cc @codeclimate/review

For some reason, `make test` errors for me locally because the container tries
to write the `Gemfile.lock` -- no idea why. I'm looking to see what happens on
Circle (this specs-in-container approach has been working there since day 1).
