### PR TITLE
Literate CoffeeScript support added

### DIFF
--- a/lib/cc/engine/analyzable_files.rb
+++ b/lib/cc/engine/analyzable_files.rb
@@ -1,3 +1,5 @@
+SUFFIXES = %w[/ .coffee .coffee.md .litcoffee].freeze
+
 module CC
   module Engine
     class AnalyzableFiles
@@ -17,7 +19,7 @@ module CC
 
       def filter_files(files)
         files.select do |file|
-          file.end_with?("/") || file.end_with?(".coffee") || file.end_with?(".coffee.md") || file.end_with?(".litcoffee")
+          SUFFIXES.any? { |suffix| file.end_with?(suffix) }
         end
       end
     end

--- a/lib/cc/engine/analyzable_files.rb
+++ b/lib/cc/engine/analyzable_files.rb
@@ -17,7 +17,7 @@ module CC
 
       def filter_files(files)
         files.select do |file|
-          file.end_with?("/") || file.end_with?(".coffee")
+          file.end_with?("/") || file.end_with?(".coffee") || file.end_with?(".coffee.md") || file.end_with?(".litcoffee")
         end
       end
     end

--- a/spec/cc/engine/analyzable_files_spec.rb
+++ b/spec/cc/engine/analyzable_files_spec.rb
@@ -5,10 +5,10 @@ module CC::Engine
     context "when given include_paths" do
       it "filters out non-directory and non-coffee files" do
         analyzable_files = AnalyzableFiles.new({
-          "include_paths" => ["foo/", "bar.py", "foo.coffee"]
+          "include_paths" => ["foo/", "bar.py", "foo.coffee", "foo.coffee.md", "foo.litcoffee"]
         })
 
-        expect(analyzable_files.all.sort).to eq(["foo.coffee", "foo/"])
+        expect(analyzable_files.all.sort).to eq(["foo.coffee", "foo.coffee.md", "foo.litcoffee", "foo/"])
       end
     end
 


### PR DESCRIPTION
Right now only files ended with `.coffee` are tested.
This PR adds support for files written in literate style. CoffeeScript recognises `.litcoffee` and `.coffee.md` files as literate.

I don't have experience in Ruby so sorry for all stupidness :)
