### PR TITLE
Add support for npm-managed CoffeeLint plugins and transformers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,11 @@ FROM codeclimate/alpine-ruby:b38
 WORKDIR /usr/src/app
 COPY Gemfile /usr/src/app/
 COPY Gemfile.lock /usr/src/app/
+COPY npm-shrinkwrap.json /usr/src/app/
+COPY package.json /usr/src/app/
 
 RUN apk --update add nodejs ruby ruby-dev ruby-bundler build-base && \
-    npm install -g coffeelint && \
+    npm install && \
     bundle install -j 4 && \
     apk del build-base && rm -fr /usr/share/ri
 

--- a/lib/cc/engine/coffeelint_results.rb
+++ b/lib/cc/engine/coffeelint_results.rb
@@ -13,7 +13,7 @@ module CC
         return [] if @files.empty?
 
         escaped_files = Shellwords.join(@files)
-        cmd = "/usr/src/app/node_modules/.bin/coffeelint"
+        cmd = File.expand_path("../../../node_modules/.bin/coffeelint", __dir__)
         cmd << " -f #{@config}" if @config
         cmd << " -q --reporter raw #{escaped_files}"
         Dir.chdir(@directory) do

--- a/lib/cc/engine/coffeelint_results.rb
+++ b/lib/cc/engine/coffeelint_results.rb
@@ -13,7 +13,7 @@ module CC
         return [] if @files.empty?
 
         escaped_files = Shellwords.join(@files)
-        cmd = "coffeelint"
+        cmd = "/usr/src/app/node_modules/.bin/coffeelint"
         cmd << " -f #{@config}" if @config
         cmd << " -q --reporter raw #{escaped_files}"
         Dir.chdir(@directory) do

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -12,6 +12,11 @@
       "from": "brace-expansion@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
     },
+    "coffee-react-transform": {
+      "version": "4.0.0",
+      "from": "coffee-react-transform@latest",
+      "resolved": "https://registry.npmjs.org/coffee-react-transform/-/coffee-react-transform-4.0.0.tgz"
+    },
     "coffee-script": {
       "version": "1.10.0",
       "from": "coffee-script@>=1.10.0 <1.11.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,91 @@
+{
+  "name": "codeclimate-coffeelint",
+  "version": "1.0.0",
+  "dependencies": {
+    "balanced-match": {
+      "version": "0.4.2",
+      "from": "balanced-match@>=0.4.1 <0.5.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+    },
+    "brace-expansion": {
+      "version": "1.1.6",
+      "from": "brace-expansion@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+    },
+    "coffee-script": {
+      "version": "1.10.0",
+      "from": "coffee-script@>=1.10.0 <1.11.0",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz"
+    },
+    "coffeelint": {
+      "version": "1.15.7",
+      "from": "coffeelint@latest",
+      "resolved": "https://registry.npmjs.org/coffeelint/-/coffeelint-1.15.7.tgz"
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "from": "concat-map@0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+    },
+    "glob": {
+      "version": "4.5.3",
+      "from": "glob@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz"
+    },
+    "ignore": {
+      "version": "3.1.3",
+      "from": "ignore@>=3.0.9 <4.0.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.1.3.tgz"
+    },
+    "inflight": {
+      "version": "1.0.5",
+      "from": "inflight@>=1.0.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz"
+    },
+    "inherits": {
+      "version": "2.0.1",
+      "from": "inherits@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+    },
+    "minimatch": {
+      "version": "2.0.10",
+      "from": "minimatch@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
+    },
+    "minimist": {
+      "version": "0.0.10",
+      "from": "minimist@>=0.0.1 <0.1.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+    },
+    "once": {
+      "version": "1.3.3",
+      "from": "once@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "from": "optimist@>=0.6.1 <0.7.0",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz"
+    },
+    "resolve": {
+      "version": "0.6.3",
+      "from": "resolve@>=0.6.3 <0.7.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz"
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "from": "strip-json-comments@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "from": "wordwrap@>=0.0.2 <0.1.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "from": "wrappy@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "homepage": "https://github.com/codeclimate/codeclimate-coffeelint#readme",
   "dependencies": {
+    "coffee-react-transform": "^4.0.0",
     "coffeelint": "^1.15.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "codeclimate-coffeelint",
+  "version": "1.0.0",
+  "description": "Code Climate Engine for CoffeeLint",
+  "scripts": {
+    "test": "bundle exec rspec"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/codeclimate/codeclimate-coffeelint.git"
+  },
+  "bugs": {
+    "url": "https://github.com/codeclimate/codeclimate-coffeelint/issues"
+  },
+  "homepage": "https://github.com/codeclimate/codeclimate-coffeelint#readme",
+  "dependencies": {
+    "coffeelint": "^1.15.7"
+  }
+}

--- a/spec/cc/engine/coffeelint_results_spec.rb
+++ b/spec/cc/engine/coffeelint_results_spec.rb
@@ -5,7 +5,7 @@ module CC::Engine
     describe "#results" do
       it "passes in a config file if specified" do
         results = CoffeelintResults.new(".", ["."], "mycoffeelint.json")
-        expected_cmd = "coffeelint -f mycoffeelint.json -q --reporter raw ."
+        expected_cmd = "/usr/src/app/node_modules/.bin/coffeelint -f mycoffeelint.json -q --reporter raw ."
         expect(results).to \
           receive(:`).with(expected_cmd).and_return("{}")
         results.results

--- a/spec/cc/engine/coffeelint_results_spec.rb
+++ b/spec/cc/engine/coffeelint_results_spec.rb
@@ -5,7 +5,8 @@ module CC::Engine
     describe "#results" do
       it "passes in a config file if specified" do
         results = CoffeelintResults.new(".", ["."], "mycoffeelint.json")
-        expected_cmd = "/usr/src/app/node_modules/.bin/coffeelint -f mycoffeelint.json -q --reporter raw ."
+        expected_executable = File.expand_path("../../../node_modules/.bin/coffeelint", __dir__)
+        expected_cmd = "#{expected_executable} -f mycoffeelint.json -q --reporter raw ."
         expect(results).to \
           receive(:`).with(expected_cmd).and_return("{}")
         results.results


### PR DESCRIPTION
CodeClimate's CoffeeLint engine currently does not allow users to configure CoffeeLint with plugins or transformers. This denies use cases such as https://github.com/clutchski/coffeelint/blob/master/doc/user.md#how-do-i-use-jsx-reactjs.

This PR aims to _partly_ resolve this feature gap by using local npm packages in the Docker app to power the CoffeeLint engine. The PR manually includes the `coffee-react-transform` transformer. A complete solution would not require users to manually include plugins and transformers in to this repo.

I'm hoping that CodeClimate can accept this short-term solution until someone has more time to work on a complete solution.
