### PR TITLE
Always specify coffeelint.json as default config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,6 @@ image:
 	docker build --tag $(IMAGE_NAME) .
 
 citest:
-	docker run --rm $(IMAGE_NAME) bundle exec rake
+	docker run --rm $(IMAGE_NAME) sh -c "cd /usr/src/app && bundle exec rake"
 
 test: image citest

--- a/lib/cc/engine/coffeelint_results.rb
+++ b/lib/cc/engine/coffeelint_results.rb
@@ -3,21 +3,35 @@ require 'shellwords'
 module CC
   module Engine
     class CoffeelintResults
+      DEFAULT_CONFIG_PATH = "/code/coffeelint.json".freeze
+
       def initialize(directory, files, config)
         @directory = directory
-        @config = config
         @files = files
+        @config = config
       end
 
       def results
-        return [] if @files.empty?
+        return [] if files.empty?
 
-        escaped_files = Shellwords.join(@files)
+        escaped_files = Shellwords.join(files)
         cmd = File.expand_path("../../../node_modules/.bin/coffeelint", __dir__)
-        cmd << " -f #{@config}" if @config
+        cmd << " -f #{config_path}" if config_path
         cmd << " -q --reporter raw #{escaped_files}"
-        Dir.chdir(@directory) do
+        Dir.chdir(directory) do
           JSON.parse(`#{cmd}`)
+        end
+      end
+
+      private
+
+      attr_reader :directory, :files, :config
+
+      def config_path
+        if config
+          config
+        elsif File.exist? DEFAULT_CONFIG_PATH
+          DEFAULT_CONFIG_PATH
         end
       end
     end


### PR DESCRIPTION
This sidesteps an issue with resolving the config and location of node_modules
for coffeelint projects using plugins:
https://github.com/clutchski/coffeelint/issues/571

@codeclimate/review 
