### PR TITLE
Remove `-q` parameter from coffeelint call to also receive warnings

### DIFF
--- a/lib/cc/engine/coffeelint_results.rb
+++ b/lib/cc/engine/coffeelint_results.rb
@@ -17,7 +17,7 @@ module CC
         escaped_files = Shellwords.join(files)
         cmd = File.expand_path("../../../node_modules/.bin/coffeelint", __dir__)
         cmd << " -f #{config_path}" if config_path
-        cmd << " -q --reporter raw #{escaped_files}"
+        cmd << " --reporter raw #{escaped_files}"
         Dir.chdir(directory) do
           JSON.parse(`#{cmd}`)
         end

--- a/spec/cc/engine/coffeelint_results_spec.rb
+++ b/spec/cc/engine/coffeelint_results_spec.rb
@@ -6,7 +6,7 @@ module CC::Engine
       it "passes in a config file if specified" do
         results = CoffeelintResults.new(".", ["."], "mycoffeelint.json")
         expected_executable = File.expand_path("../../../node_modules/.bin/coffeelint", __dir__)
-        expected_cmd = "#{expected_executable} -f mycoffeelint.json -q --reporter raw ."
+        expected_cmd = "#{expected_executable} -f mycoffeelint.json --reporter raw ."
         expect(results).to \
           receive(:`).with(expected_cmd).and_return("{}")
         results.results


### PR DESCRIPTION
Fixes #23 