### PR TITLE
Bump CoffeeScript version

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -18,9 +18,9 @@
       "resolved": "https://registry.npmjs.org/coffee-react-transform/-/coffee-react-transform-4.0.0.tgz"
     },
     "coffee-script": {
-      "version": "1.10.0",
-      "from": "coffee-script@>=1.10.0 <1.11.0",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz"
+      "version": "1.12.5",
+      "from": "coffee-script@>=1.12.0 <1.13.0",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.5.tgz"
     },
     "coffeelint": {
       "version": "1.15.7",


### PR DESCRIPTION
This lets users use ES6 modules without backticks and without tons of errors.