### PR TITLE
Bumps coffeelint 1.15.7 -> 1.16.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY Gemfile.lock /usr/src/app/
 COPY npm-shrinkwrap.json /usr/src/app/
 COPY package.json /usr/src/app/
 
-RUN apk --update add nodejs ruby ruby-dev ruby-bundler build-base && \
+RUN apk --update add nodejs nodejs-npm ruby ruby-dev ruby-bundler build-base && \
     npm install && \
     bundle install -j 4 && \
     apk del build-base && rm -fr /usr/share/ri

--- a/circle.yml
+++ b/circle.yml
@@ -4,10 +4,11 @@ machine:
   environment:
     CLOUDSDK_CORE_DISABLE_PROMPTS: 1
     PRIVATE_REGISTRY: us.gcr.io/code_climate
+    IMAGE_NAME: $PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM
 
 dependencies:
   override:
-    - IMAGE_NAME="$PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM" make image
+    - make image
 
 test:
   override:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8,9 +8,9 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
     },
     "brace-expansion": {
-      "version": "1.1.6",
-      "from": "brace-expansion@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+      "version": "1.1.7",
+      "from": "brace-expansion@>=1.1.7 <2.0.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
     },
     "coffee-react-transform": {
       "version": "4.0.0",
@@ -18,44 +18,49 @@
       "resolved": "https://registry.npmjs.org/coffee-react-transform/-/coffee-react-transform-4.0.0.tgz"
     },
     "coffee-script": {
-      "version": "1.10.0",
-      "from": "coffee-script@>=1.10.0 <1.11.0",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz"
+      "version": "1.11.1",
+      "from": "coffee-script@>=1.11.0 <1.12.0",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.11.1.tgz"
     },
     "coffeelint": {
-      "version": "1.15.7",
-      "from": "coffeelint@latest",
-      "resolved": "https://registry.npmjs.org/coffeelint/-/coffeelint-1.15.7.tgz"
+      "version": "1.16.0",
+      "from": "coffeelint@1.16.0",
+      "resolved": "https://registry.npmjs.org/coffeelint/-/coffeelint-1.16.0.tgz"
     },
     "concat-map": {
       "version": "0.0.1",
       "from": "concat-map@0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
     },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "from": "fs.realpath@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+    },
     "glob": {
-      "version": "4.5.3",
-      "from": "glob@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz"
+      "version": "7.1.1",
+      "from": "glob@>=7.0.6 <8.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
     },
     "ignore": {
-      "version": "3.1.3",
+      "version": "3.3.0",
       "from": "ignore@>=3.0.9 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.1.3.tgz"
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.0.tgz"
     },
     "inflight": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "from": "inflight@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz"
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
     },
     "inherits": {
-      "version": "2.0.1",
+      "version": "2.0.3",
       "from": "inherits@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
     },
     "minimatch": {
-      "version": "2.0.10",
-      "from": "minimatch@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
+      "version": "3.0.4",
+      "from": "minimatch@>=3.0.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
     },
     "minimist": {
       "version": "0.0.10",
@@ -63,14 +68,19 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
     },
     "once": {
-      "version": "1.3.3",
+      "version": "1.4.0",
       "from": "once@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
     },
     "optimist": {
       "version": "0.6.1",
       "from": "optimist@>=0.6.1 <0.7.0",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz"
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
     },
     "resolve": {
       "version": "0.6.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   "homepage": "https://github.com/codeclimate/codeclimate-coffeelint#readme",
   "dependencies": {
     "coffee-react-transform": "^4.0.0",
-    "coffeelint": "^1.15.7"
+    "coffeelint": "^1.16.0"
   }
 }


### PR DESCRIPTION
This also bumps the coffeescript version to `1.11.1` which together should address this issue: https://github.com/codeclimate/codeclimate-coffeelint/issues/26

To upgrade I ran in the code project:
```
> npm install
> npm update coffeelint --save
```

`nodejs` separated out `nodejs-npm` into a separate package, which is the reason for the Dockerfile change (npm is not found otherwise).
