### PR TITLE
Push images to Dockerhub instead of GCR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,19 +29,19 @@ jobs:
               circleci step halt
             fi
       - run: make image
-      - run: echo "$GCR_JSON_KEY" | docker login -u _json_key --password-stdin us.gcr.io
+      - run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       - run:
-          name: Push image to GCR
+          name: Push image to Dockerhub
           command: |
-            docker tag codeclimate/codeclimate-coffeelint \
-              us.gcr.io/code-climate/codeclimate-coffeelint:b$CIRCLE_BUILD_NUM
-            docker push us.gcr.io/code-climate/codeclimate-coffeelint:b$CIRCLE_BUILD_NUM
+            make release RELEASE_TAG="b$CIRCLE_BUILD_NUM"
+            make release RELEASE_TAG="$(echo $CIRCLE_BRANCH | grep -oP 'channel/\K[\w\-]+')"
 workflows:
   version: 2
   build_deploy:
     jobs:
       - build
       - release_images:
+          context: Quality
           requires:
             - build
           filters:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 .PHONY: image citest test release
 
-REPO_NAME ?= codeclimate-coffeelint
 IMAGE_NAME ?= codeclimate/codeclimate-coffeelint
 RELEASE_REGISTRY ?= codeclimate
 RELEASE_TAG ?= latest

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
-.PHONY: image citest test
+.PHONY: image citest test release
 
+REPO_NAME ?= codeclimate-coffeelint
 IMAGE_NAME ?= codeclimate/codeclimate-coffeelint
+RELEASE_REGISTRY ?= codeclimate
+RELEASE_TAG ?= latest
 
 image:
 	docker build --tag $(IMAGE_NAME) .
@@ -9,3 +12,7 @@ citest:
 	docker run --rm $(IMAGE_NAME) sh -c "cd /usr/src/app && bundle exec rake"
 
 test: image citest
+
+release:
+	docker tag $(IMAGE_NAME) $(RELEASE_REGISTRY)/codeclimate-coffeelint:$(RELEASE_TAG)
+	docker push $(RELEASE_REGISTRY)/codeclimate-coffeelint:$(RELEASE_TAG)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@
 
 IMAGE_NAME ?= codeclimate/codeclimate-coffeelint
 RELEASE_REGISTRY ?= codeclimate
-RELEASE_TAG ?= latest
+
+ifndef RELEASE_TAG
+override RELEASE_TAG = latest
+endif
 
 image:
 	docker build --tag $(IMAGE_NAME) .


### PR DESCRIPTION
Push images to Dockerhub instead of GCR

- For master branch:
    - push image `codeclimate-coffeelint:bXXX`
    - push image `codeclimate-coffeelint:latest`
- For channel/channel-name branches:
    - push image `codeclimate-coffeelint:bXXX`
    - push image `codeclimate-coffeelint:channel-name`